### PR TITLE
Correcting typo in dependency notice. `resolove` should be `resolve`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [coming soon]
+
+- Correcting typo in dependency notice. `resolove` should be `resolve`.
+
 ## v161026.47592
 
 - Updating to latest release of the websharks/core.

--- a/src/includes/classes/SCore/Utils/Dependencies.php
+++ b/src/includes/classes/SCore/Utils/Dependencies.php
@@ -738,7 +738,7 @@ class Dependencies extends Classes\SCore\Base\Core implements CoreInterfaces\Sec
         $markup .= '<p style="'.esc_attr($this->message_p_tag_styles).'">';
         $markup     .= $this->icon.sprintf(__('<strong>%1$s is not active.</strong> It requires %2$s.', 'wp-sharks-core'), esc_html($this->App->Config->©brand['©name']), $args['description']).'<br />';
         $markup     .= $this->arrow.' '.sprintf(__('To resolve, %1$s.', 'wp-sharks-core'), $args['how_to_resolve']).'<br />';
-        $markup     .= sprintf(__('<em style="font-size:80%%; opacity:.7;">To remove this message, resolove the issue or remove %1$s from WordPress.</em>', 'wp-sharks-core'), esc_html($this->App->Config->©brand['©name']));
+        $markup     .= sprintf(__('<em style="font-size:80%%; opacity:.7;">To remove this message, resolve the issue or remove %1$s from WordPress.</em>', 'wp-sharks-core'), esc_html($this->App->Config->©brand['©name']));
         $markup .= '</p>';
 
         add_action('all_admin_notices', function () use ($args, $markup) {

--- a/src/includes/translations/wp-sharks-core.pot
+++ b/src/includes/translations/wp-sharks-core.pot
@@ -169,7 +169,7 @@ msgid "To resolve, %1$s."
 msgstr ""
 
 #: src/includes/classes/SCore/Utils/Dependencies.php:741
-msgid "<em style=\"font-size:80%%; opacity:.7;\">To remove this message, resolove the issue or remove %1$s from WordPress.</em>"
+msgid "<em style=\"font-size:80%%; opacity:.7;\">To remove this message, resolve the issue or remove %1$s from WordPress.</em>"
 msgstr ""
 
 #: src/includes/classes/SCore/Utils/Fatality.php:44


### PR DESCRIPTION
Correcting typo in dependency notice. `resolove` should be `resolve`. See #8
